### PR TITLE
Add GitHub Actions CI/CD pipeline

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,47 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: '20.x'
+  PNPM_VERSION: '10.x'
+
+jobs:
+  test-and-build:
+    name: Test and Build
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+        cache: 'pnpm'
+        
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v2
+      with:
+        version: ${{ env.PNPM_VERSION }}
+        
+    - name: Install dependencies
+      run: pnpm install
+    - name: Build
+      run: pnpm run build
+      
+    - name: Run unit tests
+      run: pnpm run test
+      
+    # - name: Run e2e tests
+    #   run: pnpm run test:e2e
+    # - name: Lint
+    #   run: pnpm run lint
+      
+


### PR DESCRIPTION
Add GitHub Actions CI/CD pipeline for main branch

- Setup Node.js and pnpm environments
- Install dependencies
- Run build and unit tests
- Lint and e2e testing steps are currently disabled and will be added later
